### PR TITLE
Fix penalty bug in useKeyboardTime.js

### DIFF
--- a/src/useKeyboardTimer.ts
+++ b/src/useKeyboardTimer.ts
@@ -157,11 +157,11 @@ export default function useKeyboardTimer(
 			? { type: '+2', amount: 2 }
 			: undefined
 		onCompleteCallback(newTime, penalty)
+		dnf.current = false
+		plusTwo.current = false
 	}
 
 	function startTimer() {
-		dnf.current = false
-		plusTwo.current = false
 		setIsTiming(true)
 		setState('STARTED')
 		if (intervalRef.current) {


### PR DESCRIPTION
Penalties used to reset when `state` transitioned from `INSPECTION` to `STARTED` in the `startTimer` funciton.  They now reset when `stopTimer` is called.